### PR TITLE
Changes the wildcard to fetch all tags to 'any'.

### DIFF
--- a/src/QueryCommand.php
+++ b/src/QueryCommand.php
@@ -66,7 +66,7 @@ class QueryCommand
      */
     public function findByPattern($pattern, $usageType = PhpTags\Tag::DEFINITION, $ignoreCase = true, $tagType = null, $format = null)
     {
-        if ($tagType === '*') {
+        if ($tagType === 'any') {
             $tagType = null;
         }
 


### PR DESCRIPTION
Using `*` required escaping since some shells replaced it with the first filename in `$PWD`.
Use `echo *` to see the effect of the bug.

This caused PHPTags to always reject explicit searches for all types of tag.
